### PR TITLE
Fix module path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ else
 endif
 
 # The import path
-NETWORK_LATENCY_EXPORTER_PKG=github.com/Netcracker/network-latency-exporter
+NETWORK_LATENCY_EXPORTER_PKG=github.com/Netcracker/qubership-network-latency-exporter
 
 # The ldflags for the go build process to set the version related data.
 GO_BUILD_LDFLAGS=\

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -10,10 +10,10 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/Netcracker/network-latency-exporter/pkg/collector"
-	"github.com/Netcracker/network-latency-exporter/pkg/logger"
-	"github.com/Netcracker/network-latency-exporter/pkg/metrics"
-	"github.com/Netcracker/network-latency-exporter/pkg/utils"
+	"github.com/Netcracker/qubership-network-latency-exporter/pkg/collector"
+	"github.com/Netcracker/qubership-network-latency-exporter/pkg/logger"
+	"github.com/Netcracker/qubership-network-latency-exporter/pkg/metrics"
+	"github.com/Netcracker/qubership-network-latency-exporter/pkg/utils"
 
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/prometheus/client_golang/prometheus"

--- a/cmd/node_watcher.go
+++ b/cmd/node_watcher.go
@@ -5,8 +5,8 @@ import (
 
 	"log/slog"
 
-	"github.com/Netcracker/network-latency-exporter/pkg/collector"
-	"github.com/Netcracker/network-latency-exporter/pkg/utils"
+	"github.com/Netcracker/qubership-network-latency-exporter/pkg/collector"
+	"github.com/Netcracker/qubership-network-latency-exporter/pkg/utils"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/watch"
 )

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/Netcracker/network-latency-exporter
+module github.com/Netcracker/qubership-network-latency-exporter
 
 go 1.24.0
 

--- a/pkg/collector/config.go
+++ b/pkg/collector/config.go
@@ -6,8 +6,8 @@ import (
 
 	"log/slog"
 
-	"github.com/Netcracker/network-latency-exporter/pkg/metrics"
-	"github.com/Netcracker/network-latency-exporter/pkg/model"
+	"github.com/Netcracker/qubership-network-latency-exporter/pkg/metrics"
+	"github.com/Netcracker/qubership-network-latency-exporter/pkg/model"
 	"github.com/pkg/errors"
 )
 

--- a/pkg/collector/discover.go
+++ b/pkg/collector/discover.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"log/slog"
 
-	"github.com/Netcracker/network-latency-exporter/pkg/metrics"
-	"github.com/Netcracker/network-latency-exporter/pkg/utils"
+	"github.com/Netcracker/qubership-network-latency-exporter/pkg/metrics"
+	"github.com/Netcracker/qubership-network-latency-exporter/pkg/utils"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )

--- a/pkg/collector/discover_test.go
+++ b/pkg/collector/discover_test.go
@@ -6,8 +6,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/Netcracker/network-latency-exporter/pkg/metrics"
-	"github.com/Netcracker/network-latency-exporter/pkg/utils"
+	"github.com/Netcracker/qubership-network-latency-exporter/pkg/metrics"
+	"github.com/Netcracker/qubership-network-latency-exporter/pkg/utils"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/collector/node_collector.go
+++ b/pkg/collector/node_collector.go
@@ -11,9 +11,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/Netcracker/network-latency-exporter/pkg/metrics"
-	"github.com/Netcracker/network-latency-exporter/pkg/model"
-	"github.com/Netcracker/network-latency-exporter/pkg/utils"
+	"github.com/Netcracker/qubership-network-latency-exporter/pkg/metrics"
+	"github.com/Netcracker/qubership-network-latency-exporter/pkg/model"
+	"github.com/Netcracker/qubership-network-latency-exporter/pkg/utils"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 )

--- a/pkg/model/node.go
+++ b/pkg/model/node.go
@@ -1,7 +1,7 @@
 package model
 
 import (
-	"github.com/Netcracker/network-latency-exporter/pkg/metrics"
+	"github.com/Netcracker/qubership-network-latency-exporter/pkg/metrics"
 	"k8s.io/client-go/kubernetes"
 )
 

--- a/pkg/model/pod.go
+++ b/pkg/model/pod.go
@@ -1,7 +1,7 @@
 package model
 
 import (
-	"github.com/Netcracker/network-latency-exporter/pkg/metrics"
+	"github.com/Netcracker/qubership-network-latency-exporter/pkg/metrics"
 	"k8s.io/client-go/kubernetes"
 )
 

--- a/pkg/utils/utilities.go
+++ b/pkg/utils/utilities.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/Netcracker/network-latency-exporter/pkg/metrics"
+	"github.com/Netcracker/qubership-network-latency-exporter/pkg/metrics"
 
 	"log/slog"
 


### PR DESCRIPTION
## Summary
- update module path from `Netcracker/network-latency-exporter` to `Netcracker/qubership-network-latency-exporter`
- adjust Makefile paths
- run `go fmt`, `go vet`, `go test`, and `actionlint`

## Testing
- `go fmt ./...`
- `go vet ./...`
- `go test ./...`
- `make build-binary`
- `actionlint -config-file .github/linters/actionlint.yml`


------
https://chatgpt.com/codex/tasks/task_e_6863a4e41ec083238553e1dde76661c1